### PR TITLE
Modify Link.php to manage multilang values for supplier and manufacturer

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -514,8 +514,8 @@ class LinkCore
         $params = [];
         $params['id'] = $cmsCategory->id;
         $params['rewrite'] = (!$alias) ? $cmsCategory->link_rewrite : $alias;
-        $params['meta_keywords'] = Tools::str2url($cmsCategory->meta_keywords);
-        $params['meta_title'] = Tools::str2url($cmsCategory->meta_title);
+        $params['meta_keywords'] = Tools::str2url($cmsCategory->getFieldByLang('meta_keywords'));
+        $params['meta_title'] = Tools::str2url($cmsCategory->getFieldByLang('meta_title'));
 
         return $url . $dispatcher->createUrl('cms_category_rule', $idLang, $params, $this->allow, '', $idShop);
     }
@@ -618,8 +618,8 @@ class LinkCore
         $params = [];
         $params['id'] = $supplier->id;
         $params['rewrite'] = (!$alias) ? $supplier->link_rewrite : $alias;
-        $params['meta_keywords'] = Tools::str2url($supplier->meta_keywords);
-        $params['meta_title'] = Tools::str2url($supplier->meta_title);
+        $params['meta_keywords'] = Tools::str2url($supplier->getFieldByLang('meta_keywords'));
+        $params['meta_title'] = Tools::str2url($supplier->getFieldByLang('meta_title'));
 
         return $url . $dispatcher->createUrl('supplier_rule', $idLang, $params, $this->allow, '', $idShop);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In case of multilanguage system the fields meta_keywords and meta_title are array and there is no check to retrieve the correct value for the current language. The function Tools:str2url generate a warning during the cast from array to string.
| Type?             | bug fix
| Category?         | FO / BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable debug mode, be sure you have more than one active language, enable manufacturer page, add keywords and meta tile for manufacturer and in product detail page you will see the warning.
